### PR TITLE
adding html support to adapter for custom html templates

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,13 +6,14 @@ let SimpleSendGridAdapter = mailOptions => {
   }
   let sendgrid = SendGrid(mailOptions.apiKey);
 
-  let sendMail = ({to, subject, text}) => {
+  let sendMail = ({to, subject, text, html}) => {
     return new Promise((resolve, reject) => {
       sendgrid.send({
         from: mailOptions.fromAddress,
         to: to,
         subject: subject,
         text: text,
+		html: html,
       }, function(err, json) {
         if (err) {
            reject(err);


### PR DESCRIPTION
Sendgrid supports sending html in it's api, wanted to add html support to the adapter for a parse-server project